### PR TITLE
Update puppet-lint version to include 2.x

### DIFF
--- a/puppet-lint-usascii_format-check.gemspec
+++ b/puppet-lint-usascii_format-check.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
     A puppet-lint plugin to check that manifest files contain only US ASCII.
   EOF
  
-  spec.add_dependency             'puppet-lint', '~> 1.0'
+  spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rspec-its', '~> 1.0'
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'


### PR DESCRIPTION
`rake spec` runs clean with puppet-lint 2.3.0